### PR TITLE
feat: Added support for activiti:async property attribute

### DIFF
--- a/lib/helper/AsyncCapableHelper.js
+++ b/lib/helper/AsyncCapableHelper.js
@@ -19,20 +19,6 @@ function isActivitiAsync(bo) {
 module.exports.isActivitiAsync = isActivitiAsync;
 
 /**
- * Returns true if the attribute 'activiti:asyncAfter' is set
- * to true.
- *
- * @param  {ModdleElement} bo
- *
- * @return {boolean} a boolean value
- */
-function isAsyncAfter(bo) {
-  return !!bo.get('activiti:asyncAfter');
-}
-
-module.exports.isAsyncAfter = isAsyncAfter;
-
-/**
  * Returns true if the attribute 'activiti:exclusive' is set
  * to true.
  *

--- a/lib/helper/AsyncCapableHelper.js
+++ b/lib/helper/AsyncCapableHelper.js
@@ -5,18 +5,18 @@ var map = require('lodash/map');
 var extensionElementsHelper = require('./ExtensionElementsHelper');
 
 /**
- * Returns true if the attribute 'activiti:asyncBefore' is set
+ * Returns true if the attribute 'activiti:async' is set
  * to true.
  *
  * @param  {ModdleElement} bo
  *
  * @return {boolean} a boolean value
  */
-function isAsyncBefore(bo) {
-  return !!(bo.get('activiti:asyncBefore') || bo.get('activiti:async'));
+function isActivitiAsync(bo) {
+  return !!(bo.get('activiti:async'));
 }
 
-module.exports.isAsyncBefore = isAsyncBefore;
+module.exports.isActivitiAsync = isActivitiAsync;
 
 /**
  * Returns true if the attribute 'activiti:asyncAfter' is set

--- a/lib/provider/activiti/ActivitiPropertiesProvider.js
+++ b/lib/provider/activiti/ActivitiPropertiesProvider.js
@@ -100,7 +100,7 @@ var isJobConfigEnabled = function(element) {
 
   // async behavior
   var bo = getBusinessObject(element);
-  if (asyncCapableHelper.isAsyncBefore(bo) || asyncCapableHelper.isAsyncAfter(bo)) {
+  if (asyncCapableHelper.isActivitiAsync(bo) || asyncCapableHelper.isAsyncAfter(bo)) {
     return true;
   }
 

--- a/lib/provider/activiti/ActivitiPropertiesProvider.js
+++ b/lib/provider/activiti/ActivitiPropertiesProvider.js
@@ -100,7 +100,7 @@ var isJobConfigEnabled = function(element) {
 
   // async behavior
   var bo = getBusinessObject(element);
-  if (asyncCapableHelper.isActivitiAsync(bo) || asyncCapableHelper.isAsyncAfter(bo)) {
+  if (asyncCapableHelper.isActivitiAsync(bo)) {
     return true;
   }
 

--- a/lib/provider/activiti/parts/implementation/AsyncContinuation.js
+++ b/lib/provider/activiti/parts/implementation/AsyncContinuation.js
@@ -8,8 +8,8 @@ var asyncCapableHelper = require('../../../../helper/AsyncCapableHelper'),
     eventDefinitionHelper = require('../../../../helper/EventDefinitionHelper'),
     cmdHelper = require('../../../../helper/CmdHelper');
 
-function isAsyncBefore(bo) {
-  return asyncCapableHelper.isAsyncBefore(bo);
+function isActivitiAsync(bo) {
+  return asyncCapableHelper.isActivitiAsync(bo);
 }
 
 function isAsyncAfter(bo) {
@@ -35,7 +35,7 @@ module.exports = function(element, bpmnFactory, options, translate) {
   var idPrefix = options.idPrefix || '',
       labelPrefix = options.labelPrefix || '';
 
-  var asyncBeforeEntry = entryFactory.checkbox({
+  var activitiAsyncEntry = entryFactory.checkbox({
     id: idPrefix + 'async',
     label: labelPrefix + translate('Asynchronous'),
     modelProperty: 'async',
@@ -43,7 +43,7 @@ module.exports = function(element, bpmnFactory, options, translate) {
     get: function(element, node) {
       var bo = getBusinessObject(element);
       return {
-        async: isAsyncBefore(bo)
+        async: isActivitiAsync(bo)
       };
     },
 
@@ -119,9 +119,9 @@ module.exports = function(element, bpmnFactory, options, translate) {
 
     hidden: function(element) {
       var bo = getBusinessObject(element);
-      return bo && !isAsyncAfter(bo) && !isAsyncBefore(bo);
+      return bo && !isAsyncAfter(bo) && !isActivitiAsync(bo);
     }
   });
 
-  return [ asyncBeforeEntry, exclusiveEntry ];
+  return [ activitiAsyncEntry, exclusiveEntry ];
 };

--- a/lib/provider/activiti/parts/implementation/AsyncContinuation.js
+++ b/lib/provider/activiti/parts/implementation/AsyncContinuation.js
@@ -36,8 +36,8 @@ module.exports = function(element, bpmnFactory, options, translate) {
       labelPrefix = options.labelPrefix || '';
 
   var asyncBeforeEntry = entryFactory.checkbox({
-    id: idPrefix + 'asyncBefore',
-    label: labelPrefix + translate('Asynchronous Before'),
+    id: idPrefix + 'async',
+    label: labelPrefix + translate('Asynchronous'),
     modelProperty: 'async',
 
     get: function(element, node) {

--- a/lib/provider/activiti/parts/implementation/AsyncContinuation.js
+++ b/lib/provider/activiti/parts/implementation/AsyncContinuation.js
@@ -35,6 +35,39 @@ module.exports = function(element, bpmnFactory, options, translate) {
   var idPrefix = options.idPrefix || '',
       labelPrefix = options.labelPrefix || '';
 
+  var asyncEntry = entryFactory.checkbox({
+    id: idPrefix + 'async',
+    label: labelPrefix + translate('Asynchronous'),
+    modelProperty: 'async',
+
+    get: function(element, node) {
+      var bo = getBusinessObject(element);
+      return {
+        async: isAsyncBefore(bo)
+      };
+    },
+
+    set: function(element, values) {
+      var bo = getBusinessObject(element);
+      var asyncBefore = !!values.async;
+
+      var props = {
+        'activiti:async': asyncBefore
+      };
+
+      var commands = [];
+      if (!isAsyncAfter(bo) && !asyncBefore) {
+        props = assign({ 'activiti:exclusive' : true }, props);
+        if (canRemoveFailedJobRetryTimeCycle(element)) {
+          commands.push(removeFailedJobRetryTimeCycle(bo, element));
+        }
+      }
+
+      commands.push(cmdHelper.updateBusinessObject(element, bo, props));
+      return commands;
+    }
+  });
+
 
   var asyncBeforeEntry = entryFactory.checkbox({
     id: idPrefix + 'asyncBefore',
@@ -126,5 +159,5 @@ module.exports = function(element, bpmnFactory, options, translate) {
     }
   });
 
-  return [ asyncBeforeEntry, asyncAfterEntry, exclusiveEntry ];
+  return [ asyncEntry, exclusiveEntry ];
 };

--- a/lib/provider/activiti/parts/implementation/AsyncContinuation.js
+++ b/lib/provider/activiti/parts/implementation/AsyncContinuation.js
@@ -35,21 +35,21 @@ module.exports = function(element, bpmnFactory, options, translate) {
   var idPrefix = options.idPrefix || '',
       labelPrefix = options.labelPrefix || '';
 
-  var asyncEntry = entryFactory.checkbox({
-    id: idPrefix + 'async',
-    label: labelPrefix + translate('Asynchronous'),
+  var asyncBeforeEntry = entryFactory.checkbox({
+    id: idPrefix + 'asyncBefore',
+    label: labelPrefix + translate('Asynchronous Before'),
     modelProperty: 'async',
 
     get: function(element, node) {
       var bo = getBusinessObject(element);
       return {
-        async: isAsyncBefore(bo)
+        asyncBefore: isAsyncBefore(bo)
       };
     },
 
     set: function(element, values) {
       var bo = getBusinessObject(element);
-      var asyncBefore = !!values.async;
+      var asyncBefore = !!values.asyncBefore;
 
       var props = {
         'activiti:async': asyncBefore
@@ -69,74 +69,38 @@ module.exports = function(element, bpmnFactory, options, translate) {
   });
 
 
-  var asyncBeforeEntry = entryFactory.checkbox({
-    id: idPrefix + 'asyncBefore',
-    label: labelPrefix + translate('Asynchronous Before'),
-    modelProperty: 'asyncBefore',
+  // var asyncAfterEntry = entryFactory.checkbox({
+  //   id: idPrefix + 'asyncAfter',
+  //   label: labelPrefix + translate('Asynchronous After'),
+  //   modelProperty: 'asyncAfter',
 
-    get: function(element, node) {
-      var bo = getBusinessObject(element);
-      return {
-        asyncBefore: isAsyncBefore(bo)
-      };
-    },
+  //   get: function(element, node) {
+  //     var bo = getBusinessObject(element);
+  //     return {
+  //       asyncAfter: isAsyncAfter(bo)
+  //     };
+  //   },
 
-    set: function(element, values) {
-      var bo = getBusinessObject(element);
-      var asyncBefore = !!values.asyncBefore;
+  //   set: function(element, values) {
+  //     var bo = getBusinessObject(element);
+  //     var asyncAfter = !!values.asyncAfter;
 
-      var props = {
-        'activiti:asyncBefore': asyncBefore,
-        'activiti:async': false
-      };
+  //     var props = {
+  //       'activiti:asyncAfter': asyncAfter
+  //     };
 
-      var commands = [];
-      if (!isAsyncAfter(bo) && !asyncBefore) {
-        props = assign({ 'activiti:exclusive' : true }, props);
-        if (canRemoveFailedJobRetryTimeCycle(element)) {
-          commands.push(removeFailedJobRetryTimeCycle(bo, element));
-        }
-      }
+  //     var commands = [];
+  //     if (!isAsyncBefore(bo) && !asyncAfter) {
+  //       props = assign({ 'activiti:exclusive' : true }, props);
+  //       if (canRemoveFailedJobRetryTimeCycle(element)) {
+  //         commands.push(removeFailedJobRetryTimeCycle(bo, element));
+  //       }
+  //     }
 
-      commands.push(cmdHelper.updateBusinessObject(element, bo, props));
-      return commands;
-    }
-  });
-
-
-  var asyncAfterEntry = entryFactory.checkbox({
-    id: idPrefix + 'asyncAfter',
-    label: labelPrefix + translate('Asynchronous After'),
-    modelProperty: 'asyncAfter',
-
-    get: function(element, node) {
-      var bo = getBusinessObject(element);
-      return {
-        asyncAfter: isAsyncAfter(bo)
-      };
-    },
-
-    set: function(element, values) {
-      var bo = getBusinessObject(element);
-      var asyncAfter = !!values.asyncAfter;
-
-      var props = {
-        'activiti:asyncAfter': asyncAfter
-      };
-
-      var commands = [];
-      if (!isAsyncBefore(bo) && !asyncAfter) {
-        props = assign({ 'activiti:exclusive' : true }, props);
-        if (canRemoveFailedJobRetryTimeCycle(element)) {
-          commands.push(removeFailedJobRetryTimeCycle(bo, element));
-        }
-      }
-
-      commands.push(cmdHelper.updateBusinessObject(element, bo, props));
-      return commands;
-    }
-  });
-
+  //     commands.push(cmdHelper.updateBusinessObject(element, bo, props));
+  //     return commands;
+  //   }
+  // });
 
   var exclusiveEntry = entryFactory.checkbox({
     id: idPrefix + 'exclusive',
@@ -159,5 +123,5 @@ module.exports = function(element, bpmnFactory, options, translate) {
     }
   });
 
-  return [ asyncEntry, exclusiveEntry ];
+  return [ asyncBeforeEntry, exclusiveEntry ];
 };

--- a/lib/provider/activiti/parts/implementation/AsyncContinuation.js
+++ b/lib/provider/activiti/parts/implementation/AsyncContinuation.js
@@ -43,20 +43,20 @@ module.exports = function(element, bpmnFactory, options, translate) {
     get: function(element, node) {
       var bo = getBusinessObject(element);
       return {
-        asyncBefore: isAsyncBefore(bo)
+        async: isAsyncBefore(bo)
       };
     },
 
     set: function(element, values) {
       var bo = getBusinessObject(element);
-      var asyncBefore = !!values.asyncBefore;
+      var async = !!values.async;
 
       var props = {
-        'activiti:async': asyncBefore
+        'activiti:async': async
       };
 
       var commands = [];
-      if (!isAsyncAfter(bo) && !asyncBefore) {
+      if (!isAsyncAfter(bo) && !async) {
         props = assign({ 'activiti:exclusive' : true }, props);
         if (canRemoveFailedJobRetryTimeCycle(element)) {
           commands.push(removeFailedJobRetryTimeCycle(bo, element));

--- a/lib/provider/activiti/parts/implementation/AsyncContinuation.js
+++ b/lib/provider/activiti/parts/implementation/AsyncContinuation.js
@@ -12,10 +12,6 @@ function isActivitiAsync(bo) {
   return asyncCapableHelper.isActivitiAsync(bo);
 }
 
-function isAsyncAfter(bo) {
-  return asyncCapableHelper.isAsyncAfter(bo);
-}
-
 function isExclusive(bo) {
   return asyncCapableHelper.isExclusive(bo);
 }
@@ -49,14 +45,14 @@ module.exports = function(element, bpmnFactory, options, translate) {
 
     set: function(element, values) {
       var bo = getBusinessObject(element);
-      var async = !!values.async;
+      var asyncValue = !!values.async;
 
       var props = {
-        'activiti:async': async
+        'activiti:async': asyncValue
       };
 
       var commands = [];
-      if (!isAsyncAfter(bo) && !async) {
+      if (!asyncValue) {
         props = assign({ 'activiti:exclusive' : true }, props);
         if (canRemoveFailedJobRetryTimeCycle(element)) {
           commands.push(removeFailedJobRetryTimeCycle(bo, element));
@@ -67,40 +63,6 @@ module.exports = function(element, bpmnFactory, options, translate) {
       return commands;
     }
   });
-
-
-  // var asyncAfterEntry = entryFactory.checkbox({
-  //   id: idPrefix + 'asyncAfter',
-  //   label: labelPrefix + translate('Asynchronous After'),
-  //   modelProperty: 'asyncAfter',
-
-  //   get: function(element, node) {
-  //     var bo = getBusinessObject(element);
-  //     return {
-  //       asyncAfter: isAsyncAfter(bo)
-  //     };
-  //   },
-
-  //   set: function(element, values) {
-  //     var bo = getBusinessObject(element);
-  //     var asyncAfter = !!values.asyncAfter;
-
-  //     var props = {
-  //       'activiti:asyncAfter': asyncAfter
-  //     };
-
-  //     var commands = [];
-  //     if (!isAsyncBefore(bo) && !asyncAfter) {
-  //       props = assign({ 'activiti:exclusive' : true }, props);
-  //       if (canRemoveFailedJobRetryTimeCycle(element)) {
-  //         commands.push(removeFailedJobRetryTimeCycle(bo, element));
-  //       }
-  //     }
-
-  //     commands.push(cmdHelper.updateBusinessObject(element, bo, props));
-  //     return commands;
-  //   }
-  // });
 
   var exclusiveEntry = entryFactory.checkbox({
     id: idPrefix + 'exclusive',
@@ -119,7 +81,7 @@ module.exports = function(element, bpmnFactory, options, translate) {
 
     hidden: function(element) {
       var bo = getBusinessObject(element);
-      return bo && !isAsyncAfter(bo) && !isActivitiAsync(bo);
+      return bo && !isActivitiAsync(bo);
     }
   });
 

--- a/lib/provider/activiti/parts/implementation/JobRetryTimeCycle.js
+++ b/lib/provider/activiti/parts/implementation/JobRetryTimeCycle.js
@@ -14,10 +14,6 @@ function isActivitiAsync(bo) {
   return asyncCapableHelper.isActivitiAsync(bo);
 }
 
-function isAsyncAfter(bo) {
-  return asyncCapableHelper.isAsyncAfter(bo);
-}
-
 function getFailedJobRetryTimeCycle(bo) {
   return asyncCapableHelper.getFailedJobRetryTimeCycle(bo);
 }
@@ -95,7 +91,7 @@ module.exports = function(element, bpmnFactory, options, translate) {
     hidden: function(element) {
       var bo = getBusinessObject(element);
 
-      if (bo && (isActivitiAsync(bo) || isAsyncAfter(bo))) {
+      if (bo && isActivitiAsync(bo)) {
         return false;
       }
 

--- a/lib/provider/activiti/parts/implementation/JobRetryTimeCycle.js
+++ b/lib/provider/activiti/parts/implementation/JobRetryTimeCycle.js
@@ -10,8 +10,8 @@ var elementHelper = require('../../../../helper/ElementHelper'),
     eventDefinitionHelper = require('../../../../helper/EventDefinitionHelper'),
     cmdHelper = require('../../../../helper/CmdHelper');
 
-function isAsyncBefore(bo) {
-  return asyncCapableHelper.isAsyncBefore(bo);
+function isActivitiAsync(bo) {
+  return asyncCapableHelper.isActivitiAsync(bo);
 }
 
 function isAsyncAfter(bo) {
@@ -95,7 +95,7 @@ module.exports = function(element, bpmnFactory, options, translate) {
     hidden: function(element) {
       var bo = getBusinessObject(element);
 
-      if (bo && (isAsyncBefore(bo) || isAsyncAfter(bo))) {
+      if (bo && (isActivitiAsync(bo) || isAsyncAfter(bo))) {
         return false;
       }
 

--- a/lib/provider/activiti/parts/implementation/SignalEventDefinitionScope.js
+++ b/lib/provider/activiti/parts/implementation/SignalEventDefinitionScope.js
@@ -4,12 +4,18 @@ var elementReferenceProperty = require('../../../bpmn/parts/implementation/Eleme
 
 module.exports = function(group, element, bpmnFactory, signalEventDefinition) {
 
+  var SCOPE_OPTIONS = [
+    { value: 'global', name: 'global' },
+    { value: 'processInstance', name: 'processInstance' },
+  ];  
+
   group.entries = group.entries.concat(elementReferenceProperty(element, signalEventDefinition, bpmnFactory, {
     id: 'signal-element-scope',
     label: 'Signal Scope',
     referenceProperty: 'signalRef',
     modelProperty: 'activiti:scope',
-    shouldValidate: true
+    shouldValidate: true,
+    selectOptions: SCOPE_OPTIONS
   }));
 
 };

--- a/lib/provider/activiti/parts/implementation/SignalEventDefinitionScope.js
+++ b/lib/provider/activiti/parts/implementation/SignalEventDefinitionScope.js
@@ -4,18 +4,12 @@ var elementReferenceProperty = require('../../../bpmn/parts/implementation/Eleme
 
 module.exports = function(group, element, bpmnFactory, signalEventDefinition) {
 
-  var SCOPE_OPTIONS = [
-    { value: 'global', name: 'global' },
-    { value: 'processInstance', name: 'processInstance' },
-  ];
-
   group.entries = group.entries.concat(elementReferenceProperty(element, signalEventDefinition, bpmnFactory, {
     id: 'signal-element-scope',
     label: 'Signal Scope',
     referenceProperty: 'signalRef',
     modelProperty: 'activiti:scope',
-    shouldValidate: true,
-    selectOptions: SCOPE_OPTIONS
+    shouldValidate: true
   }));
 
 };

--- a/lib/provider/activiti/parts/implementation/SignalEventDefinitionScope.js
+++ b/lib/provider/activiti/parts/implementation/SignalEventDefinitionScope.js
@@ -7,7 +7,7 @@ module.exports = function(group, element, bpmnFactory, signalEventDefinition) {
   var SCOPE_OPTIONS = [
     { value: 'global', name: 'global' },
     { value: 'processInstance', name: 'processInstance' },
-  ];  
+  ];
 
   group.entries = group.entries.concat(elementReferenceProperty(element, signalEventDefinition, bpmnFactory, {
     id: 'signal-element-scope',

--- a/lib/provider/bpmn/parts/implementation/ElementReferenceProperty.js
+++ b/lib/provider/bpmn/parts/implementation/ElementReferenceProperty.js
@@ -27,11 +27,14 @@ module.exports = function(element, definition, bpmnFactory, options) {
   var referenceProperty = options.referenceProperty;
   var modelProperty = options.modelProperty || 'name';
   var shouldValidate = options.shouldValidate || false;
+  var selectOptions = options.selectOptions || false;
+  var entryField = selectOptions ? entryFactory.selectBox : entryFactory.textField;
 
-  var entry = entryFactory.textField({
+  var entry = entryField({
     id: id,
     label: label,
     modelProperty: modelProperty,
+    selectOptions: selectOptions,
 
     get: function(element, node) {
       var reference = definition.get(referenceProperty);

--- a/lib/provider/bpmn/parts/implementation/ElementReferenceProperty.js
+++ b/lib/provider/bpmn/parts/implementation/ElementReferenceProperty.js
@@ -27,14 +27,11 @@ module.exports = function(element, definition, bpmnFactory, options) {
   var referenceProperty = options.referenceProperty;
   var modelProperty = options.modelProperty || 'name';
   var shouldValidate = options.shouldValidate || false;
-  var selectOptions = options.selectOptions || false;
-  var entryField = selectOptions ? entryFactory.selectBox : entryFactory.textField;
 
-  var entry = entryField({
+  var entry = entryFactory.textField({
     id: id,
     label: label,
     modelProperty: modelProperty,
-    selectOptions: selectOptions,
 
     get: function(element, node) {
       var reference = definition.get(referenceProperty);

--- a/package-lock.json
+++ b/package-lock.json
@@ -493,8 +493,8 @@
       }
     },
     "activiti-bpmn-moddle": {
-      "version": "https://github.com/igdianov/activiti-bpmn-moddle/archive/v1.0.4.tar.gz",
-      "integrity": "sha512-TNHjqPcBIa6UmFbrWH8K1VSw5PMjoxpaQRvM28MXeSMlmmkQYhX9J9xxOtUhAnvzaRfik006/bzYLUn0HZBhog==",
+      "version": "https://github.com/igdianov/activiti-bpmn-moddle/archive/v1.0.5.tar.gz",
+      "integrity": "sha512-Fpc+FLSrFy53gzgspB/FyyNXVDg+etDCq6X0P6UtuzIbNTVrpDY8AY2zaf+X8nVkUmpkoEgf7eZomU78aSt+1Q==",
       "dev": true,
       "requires": {
         "min-dash": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "bpmn-js": "^3.1.0",
     "bpmn-moddle": "^5.1.6",
-    "activiti-bpmn-moddle": "https://github.com/igdianov/activiti-bpmn-moddle/archive/v1.0.4.tar.gz",
+    "activiti-bpmn-moddle": "https://github.com/igdianov/activiti-bpmn-moddle/archive/v1.0.5.tar.gz",
     "chai": "^4.1.2",
     "diagram-js": "^3.1.0",
     "eslint": "^5.2.0",

--- a/test/spec/provider/activiti/AsynchronousContinuations.bpmn
+++ b/test/spec/provider/activiti/AsynchronousContinuations.bpmn
@@ -14,7 +14,7 @@
       <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>
     </bpmn2:callActivity>
     <bpmn2:sequenceFlow id="SequenceFlow_2" name="" sourceRef="IntermediateThrowEvent_1" targetRef="CallActivity_2" />
-    <bpmn2:serviceTask id="ServiceTask" activiti:asyncBefore="true">
+    <bpmn2:serviceTask id="ServiceTask" activiti:async="true">
       <bpmn2:extensionElements>
         <activiti:inputOutput>
           <activiti:inputParameter name="asd" />
@@ -22,12 +22,12 @@
         <activiti:failedJobRetryTimeCycle>asd</activiti:failedJobRetryTimeCycle>
       </bpmn2:extensionElements>
     </bpmn2:serviceTask>
-    <bpmn2:serviceTask id="ServiceTask2" activiti:asyncBefore="true">
+    <bpmn2:serviceTask id="ServiceTask2" activiti:async="true">
       <bpmn2:extensionElements>
         <activiti:failedJobRetryTimeCycle>asd</activiti:failedJobRetryTimeCycle>
       </bpmn2:extensionElements>
     </bpmn2:serviceTask>
-    <bpmn2:startEvent id="StartEvent_Timer" activiti:asyncBefore="true">
+    <bpmn2:startEvent id="StartEvent_Timer" activiti:async="true">
       <bpmn2:extensionElements>
         <activiti:failedJobRetryTimeCycle>R3/PT10S</activiti:failedJobRetryTimeCycle>
       </bpmn2:extensionElements>

--- a/test/spec/provider/activiti/AsynchronousContinuationsSpec.js
+++ b/test/spec/provider/activiti/AsynchronousContinuationsSpec.js
@@ -15,7 +15,7 @@ var propertiesPanelModule = require('lib'),
     activitiModdlePackage = require('activiti-bpmn-moddle/resources/activiti'),
     getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
 
-function getAsyncBefore(container) {
+function getActivitiAsync(container) {
   return domQuery('div[data-entry=async] input[name=async]', container);
 }
 
@@ -60,14 +60,14 @@ describe('flow-node-properties', function() {
   }));
 
 
-  it('should set the asyncBefore property of a gateway flow node', inject(function(propertiesPanel, selection, elementRegistry) {
+  it('should set the async property of a gateway flow node', inject(function(propertiesPanel, selection, elementRegistry) {
 
     // given
     var shape = elementRegistry.get('InclusiveGateway_1');
 
     selection.select(shape);
 
-    var asyncBefore = getAsyncBefore(propertiesPanel._container),
+    var activitiAsync = getActivitiAsync(propertiesPanel._container),
         taskBo = getBusinessObject(shape);
 
     // assume
@@ -76,7 +76,7 @@ describe('flow-node-properties', function() {
 
     // when
     // I click on the checkbox
-    TestHelper.triggerEvent(asyncBefore, 'click');
+    TestHelper.triggerEvent(activitiAsync, 'click');
 
     // then
     // the value is true in the model
@@ -84,14 +84,14 @@ describe('flow-node-properties', function() {
   }));
 
 
-  it('should set the asyncBefore property of a event flow node', inject(function(propertiesPanel, selection, elementRegistry) {
+  it('should set the async property of a event flow node', inject(function(propertiesPanel, selection, elementRegistry) {
 
     // given
     var shape = elementRegistry.get('IntermediateThrowEvent_1');
 
     selection.select(shape);
 
-    var asyncBefore = getAsyncBefore(propertiesPanel._container),
+    var activitiAsync = getActivitiAsync(propertiesPanel._container),
         taskBo = getBusinessObject(shape);
 
     // assume
@@ -100,7 +100,7 @@ describe('flow-node-properties', function() {
 
     // when
     // I click on the checkbox
-    TestHelper.triggerEvent(asyncBefore, 'click');
+    TestHelper.triggerEvent(activitiAsync, 'click');
 
     // then
     // the value is true in the model
@@ -108,14 +108,14 @@ describe('flow-node-properties', function() {
   }));
 
 
-  it('should set the asyncBefore property of a activity flow node', inject(function(propertiesPanel, selection, elementRegistry) {
+  it('should set the async property of a activity flow node', inject(function(propertiesPanel, selection, elementRegistry) {
 
     // given
     var shape = elementRegistry.get('CallActivity_2');
 
     selection.select(shape);
 
-    var asyncBefore = getAsyncBefore(propertiesPanel._container),
+    var activitiAsync = getActivitiAsync(propertiesPanel._container),
         taskBo = getBusinessObject(shape);
 
     // assume
@@ -124,7 +124,7 @@ describe('flow-node-properties', function() {
 
     // when
     // I click on the checkbox
-    TestHelper.triggerEvent(asyncBefore, 'click');
+    TestHelper.triggerEvent(activitiAsync, 'click');
 
     // then
     // the value is true in the model
@@ -230,11 +230,11 @@ describe('flow-node-properties', function() {
 
     selection.select(shape);
 
-    var asyncBeforeCheckbox = getAsyncBefore(propertiesPanel._container),
+    var activitiAsyncCheckbox = getActivitiAsync(propertiesPanel._container),
         exclusiveCheckbox = domQuery('div[data-entry=exclusive] input[name=exclusive]', propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
-    TestHelper.triggerEvent(asyncBeforeCheckbox, 'click');
+    TestHelper.triggerEvent(activitiAsyncCheckbox, 'click');
 
     // assume
     expect(businessObject.get('exclusive')).to.be.true;
@@ -259,22 +259,22 @@ describe('flow-node-properties', function() {
     selection.select(shape);
 
     var exclusiveInput = getExclusive(propertiesPanel._container),
-        asyncBeforeInput = getAsyncBefore(propertiesPanel._container),
+        activitiAsyncInput = getActivitiAsync(propertiesPanel._container),
         businessObject = getBusinessObject(shape);
 
     // assume
     expect(businessObject.get('exclusive')).to.be.ok;
     expect(exclusiveInput.selected).to.not.be.true;
-    expect(asyncBeforeInput.selected).to.not.be.true;
+    expect(activitiAsyncInput.selected).to.not.be.true;
     expect(businessObject.get('async')).to.not.be.ok;
 
     // when
     // I click on the checkbox
-    TestHelper.triggerEvent(asyncBeforeInput, 'click'); // make the exclusive field visible
+    TestHelper.triggerEvent(activitiAsyncInput, 'click'); // make the exclusive field visible
 
     TestHelper.triggerEvent(exclusiveInput, 'click'); // change value of the exclusive field
 
-    TestHelper.triggerEvent(asyncBeforeInput, 'click'); // reset the exclusive field
+    TestHelper.triggerEvent(activitiAsyncInput, 'click'); // reset the exclusive field
 
     // then
     expect(exclusiveInput.checked).to.equal(businessObject.get('exclusive'));
@@ -291,7 +291,7 @@ describe('flow-node-properties', function() {
 
     selection.select(shape);
 
-    var domElement = getAsyncBefore(propertiesPanel._container);
+    var domElement = getActivitiAsync(propertiesPanel._container);
 
     // when
     TestHelper.triggerEvent(domElement, 'click');
@@ -311,7 +311,7 @@ describe('flow-node-properties', function() {
 
     selection.select(shape);
 
-    var domElement = getAsyncBefore(propertiesPanel._container);
+    var domElement = getActivitiAsync(propertiesPanel._container);
 
     // when
     TestHelper.triggerEvent(domElement, 'click');
@@ -321,7 +321,7 @@ describe('flow-node-properties', function() {
   }));
 
 
-  it('should show activiti:async as asyncBefore in the ui', inject(function(propertiesPanel, selection, elementRegistry) {
+  it('should show activiti:async in the ui', inject(function(propertiesPanel, selection, elementRegistry) {
 
     // given
     var shape = elementRegistry.get('ServiceTask');
@@ -330,24 +330,24 @@ describe('flow-node-properties', function() {
     selection.select(shape);
 
     // then
-    var asyncBeforeField = getAsyncBefore(propertiesPanel._container);
+    var activitiAsyncField = getActivitiAsync(propertiesPanel._container);
 
-    expect(!!asyncBeforeField.checked).to.be.ok;
+    expect(!!activitiAsyncField.checked).to.be.ok;
 
   }));
 
 
-  it('should migrate activiti:async to asyncBefore when asyncBefore is toggled', inject(function(propertiesPanel, selection, elementRegistry) {
+  it('should migrate activiti:async to async when async is toggled', inject(function(propertiesPanel, selection, elementRegistry) {
 
     // given
     var shape = elementRegistry.get('ServiceTask');
 
     selection.select(shape);
 
-    var asyncBeforeField = getAsyncBefore(propertiesPanel._container);
+    var activitiAsyncField = getActivitiAsync(propertiesPanel._container);
 
     // when
-    TestHelper.triggerEvent(asyncBeforeField, 'click');
+    TestHelper.triggerEvent(activitiAsyncField, 'click');
 
     // then
     var bo = getBusinessObject(shape);
@@ -366,7 +366,7 @@ describe('flow-node-properties', function() {
 
     selection.select(shape);
 
-    var domElement = getAsyncBefore(propertiesPanel._container);
+    var domElement = getActivitiAsync(propertiesPanel._container);
 
     expect(domElement.checked).to.be.true;
     expect(extensionElements[0].$type).to.equal('activiti:FailedJobRetryTimeCycle');

--- a/test/spec/provider/activiti/AsynchronousContinuationsSpec.js
+++ b/test/spec/provider/activiti/AsynchronousContinuationsSpec.js
@@ -16,7 +16,7 @@ var propertiesPanelModule = require('lib'),
     getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
 
 function getAsyncBefore(container) {
-  return domQuery('div[data-entry=asyncBefore] input[name=asyncBefore]', container);
+  return domQuery('div[data-entry=async] input[name=async]', container);
 }
 
 function getAsyncAfter(container) {
@@ -72,7 +72,7 @@ describe('flow-node-properties', function() {
 
     // assume
     // that the asyncBefore is false
-    expect(taskBo.get('asyncBefore')).to.not.be.ok;
+    expect(taskBo.get('async')).to.not.be.ok;
 
     // when
     // I click on the checkbox
@@ -80,7 +80,7 @@ describe('flow-node-properties', function() {
 
     // then
     // the value is true in the model
-    expect(taskBo.get('asyncBefore')).to.be.ok;
+    expect(taskBo.get('async')).to.be.ok;
   }));
 
 
@@ -96,7 +96,7 @@ describe('flow-node-properties', function() {
 
     // assume
     // that the asyncBefore is false
-    expect(taskBo.get('asyncBefore')).to.not.be.ok;
+    expect(taskBo.get('async')).to.not.be.ok;
 
     // when
     // I click on the checkbox
@@ -104,7 +104,7 @@ describe('flow-node-properties', function() {
 
     // then
     // the value is true in the model
-    expect(taskBo.get('asyncBefore')).to.be.ok;
+    expect(taskBo.get('async')).to.be.ok;
   }));
 
 
@@ -120,7 +120,7 @@ describe('flow-node-properties', function() {
 
     // assume
     // that the asyncBefore is false
-    expect(taskBo.get('asyncBefore')).to.not.be.ok;
+    expect(taskBo.get('async')).to.not.be.ok;
 
     // when
     // I click on the checkbox
@@ -128,82 +128,82 @@ describe('flow-node-properties', function() {
 
     // then
     // the value is true in the model
-    expect(taskBo.get('asyncBefore')).to.be.ok;
+    expect(taskBo.get('async')).to.be.ok;
   }));
 
 
-  it('should set the asyncAfter property of a gateway flow node', inject(function(propertiesPanel, selection, elementRegistry) {
+  // it('should set the asyncAfter property of a gateway flow node', inject(function(propertiesPanel, selection, elementRegistry) {
 
-    // given
-    var shape = elementRegistry.get('InclusiveGateway_1');
+  //   // given
+  //   var shape = elementRegistry.get('InclusiveGateway_1');
 
-    selection.select(shape);
+  //   selection.select(shape);
 
-    var asyncAfter = getAsyncAfter(propertiesPanel._container),
-        taskBo = getBusinessObject(shape);
+  //   var asyncAfter = getAsyncAfter(propertiesPanel._container),
+  //       taskBo = getBusinessObject(shape);
 
-    // assume
-    // that the asyncAfter is false
-    expect(taskBo.get('asyncAfter')).to.not.be.ok;
+  //   // assume
+  //   // that the asyncAfter is false
+  //   expect(taskBo.get('asyncAfter')).to.not.be.ok;
 
-    // when
-    // I click on the checkbox
-    TestHelper.triggerEvent(asyncAfter, 'click');
+  //   // when
+  //   // I click on the checkbox
+  //   TestHelper.triggerEvent(asyncAfter, 'click');
 
-    // then
-    // the value is true in the model
-    expect(taskBo.get('asyncAfter')).to.be.ok;
-  }));
-
-
-  it('should set the asyncAfter property of a event flow node', inject(function(propertiesPanel, selection, elementRegistry) {
-
-    // given
-    var shape = elementRegistry.get('IntermediateThrowEvent_1');
-
-    selection.select(shape);
-
-    var checkbox = getAsyncAfter(propertiesPanel._container),
-        taskBo = getBusinessObject(shape);
-
-    // assume
-    // that the asyncAfter property is false (unset)
-    expect(taskBo.get('asyncAfter')).to.not.be.ok;
-    expect(checkbox.selected).to.not.be.true;
-
-    // when
-    // I click on the checkbox
-    TestHelper.triggerEvent(checkbox, 'click');
-
-    // then
-    // the value is true in the model
-    expect(taskBo.get('asyncAfter')).to.be.ok;
-
-  }));
+  //   // then
+  //   // the value is true in the model
+  //   expect(taskBo.get('asyncAfter')).to.be.ok;
+  // }));
 
 
-  it('should set the asyncAfter property of a activity flow node', inject(function(propertiesPanel, selection, elementRegistry) {
+  // it('should set the asyncAfter property of a event flow node', inject(function(propertiesPanel, selection, elementRegistry) {
 
-    // given
-    var shape = elementRegistry.get('CallActivity_2');
+  //   // given
+  //   var shape = elementRegistry.get('IntermediateThrowEvent_1');
 
-    selection.select(shape);
+  //   selection.select(shape);
 
-    var asyncAfter = getAsyncAfter(propertiesPanel._container),
-        taskBo = getBusinessObject(shape);
+  //   var checkbox = getAsyncAfter(propertiesPanel._container),
+  //       taskBo = getBusinessObject(shape);
 
-    // assume
-    // that the asyncAfter is false (unset)
-    expect(taskBo.get('asyncAfter')).to.not.be.ok;
+  //   // assume
+  //   // that the asyncAfter property is false (unset)
+  //   expect(taskBo.get('asyncAfter')).to.not.be.ok;
+  //   expect(checkbox.selected).to.not.be.true;
 
-    // when
-    // I click on the checkbox
-    TestHelper.triggerEvent(asyncAfter, 'click');
+  //   // when
+  //   // I click on the checkbox
+  //   TestHelper.triggerEvent(checkbox, 'click');
 
-    // then
-    // the value is true in the model
-    expect(taskBo.get('asyncAfter')).to.be.ok;
-  }));
+  //   // then
+  //   // the value is true in the model
+  //   expect(taskBo.get('asyncAfter')).to.be.ok;
+
+  // }));
+
+
+  // it('should set the asyncAfter property of a activity flow node', inject(function(propertiesPanel, selection, elementRegistry) {
+
+  //   // given
+  //   var shape = elementRegistry.get('CallActivity_2');
+
+  //   selection.select(shape);
+
+  //   var asyncAfter = getAsyncAfter(propertiesPanel._container),
+  //       taskBo = getBusinessObject(shape);
+
+  //   // assume
+  //   // that the asyncAfter is false (unset)
+  //   expect(taskBo.get('asyncAfter')).to.not.be.ok;
+
+  //   // when
+  //   // I click on the checkbox
+  //   TestHelper.triggerEvent(asyncAfter, 'click');
+
+  //   // then
+  //   // the value is true in the model
+  //   expect(taskBo.get('asyncAfter')).to.be.ok;
+  // }));
 
 
   it('should fetch the exclusive property for a flow node', inject(function(propertiesPanel, selection, elementRegistry) {
@@ -266,7 +266,7 @@ describe('flow-node-properties', function() {
     expect(businessObject.get('exclusive')).to.be.ok;
     expect(exclusiveInput.selected).to.not.be.true;
     expect(asyncBeforeInput.selected).to.not.be.true;
-    expect(businessObject.get('asyncBefore')).to.not.be.ok;
+    expect(businessObject.get('async')).to.not.be.ok;
 
     // when
     // I click on the checkbox

--- a/test/spec/provider/activiti/AsynchronousContinuationsSpec.js
+++ b/test/spec/provider/activiti/AsynchronousContinuationsSpec.js
@@ -19,10 +19,6 @@ function getActivitiAsync(container) {
   return domQuery('div[data-entry=async] input[name=async]', container);
 }
 
-// function getAsyncAfter(container) {
-//   return domQuery('div[data-entry=asyncAfter] input[name=asyncAfter]', container);
-// }
-
 function getExclusive(container) {
   return domQuery('div[data-entry=exclusive] input[name=exclusive]', container);
 }
@@ -130,80 +126,6 @@ describe('flow-node-properties', function() {
     // the value is true in the model
     expect(taskBo.get('async')).to.be.ok;
   }));
-
-
-  // it('should set the asyncAfter property of a gateway flow node', inject(function(propertiesPanel, selection, elementRegistry) {
-
-  //   // given
-  //   var shape = elementRegistry.get('InclusiveGateway_1');
-
-  //   selection.select(shape);
-
-  //   var asyncAfter = getAsyncAfter(propertiesPanel._container),
-  //       taskBo = getBusinessObject(shape);
-
-  //   // assume
-  //   // that the asyncAfter is false
-  //   expect(taskBo.get('asyncAfter')).to.not.be.ok;
-
-  //   // when
-  //   // I click on the checkbox
-  //   TestHelper.triggerEvent(asyncAfter, 'click');
-
-  //   // then
-  //   // the value is true in the model
-  //   expect(taskBo.get('asyncAfter')).to.be.ok;
-  // }));
-
-
-  // it('should set the asyncAfter property of a event flow node', inject(function(propertiesPanel, selection, elementRegistry) {
-
-  //   // given
-  //   var shape = elementRegistry.get('IntermediateThrowEvent_1');
-
-  //   selection.select(shape);
-
-  //   var checkbox = getAsyncAfter(propertiesPanel._container),
-  //       taskBo = getBusinessObject(shape);
-
-  //   // assume
-  //   // that the asyncAfter property is false (unset)
-  //   expect(taskBo.get('asyncAfter')).to.not.be.ok;
-  //   expect(checkbox.selected).to.not.be.true;
-
-  //   // when
-  //   // I click on the checkbox
-  //   TestHelper.triggerEvent(checkbox, 'click');
-
-  //   // then
-  //   // the value is true in the model
-  //   expect(taskBo.get('asyncAfter')).to.be.ok;
-
-  // }));
-
-
-  // it('should set the asyncAfter property of a activity flow node', inject(function(propertiesPanel, selection, elementRegistry) {
-
-  //   // given
-  //   var shape = elementRegistry.get('CallActivity_2');
-
-  //   selection.select(shape);
-
-  //   var asyncAfter = getAsyncAfter(propertiesPanel._container),
-  //       taskBo = getBusinessObject(shape);
-
-  //   // assume
-  //   // that the asyncAfter is false (unset)
-  //   expect(taskBo.get('asyncAfter')).to.not.be.ok;
-
-  //   // when
-  //   // I click on the checkbox
-  //   TestHelper.triggerEvent(asyncAfter, 'click');
-
-  //   // then
-  //   // the value is true in the model
-  //   expect(taskBo.get('asyncAfter')).to.be.ok;
-  // }));
 
 
   it('should fetch the exclusive property for a flow node', inject(function(propertiesPanel, selection, elementRegistry) {

--- a/test/spec/provider/activiti/AsynchronousContinuationsSpec.js
+++ b/test/spec/provider/activiti/AsynchronousContinuationsSpec.js
@@ -19,9 +19,9 @@ function getAsyncBefore(container) {
   return domQuery('div[data-entry=async] input[name=async]', container);
 }
 
-function getAsyncAfter(container) {
-  return domQuery('div[data-entry=asyncAfter] input[name=asyncAfter]', container);
-}
+// function getAsyncAfter(container) {
+//   return domQuery('div[data-entry=asyncAfter] input[name=asyncAfter]', container);
+// }
 
 function getExclusive(container) {
   return domQuery('div[data-entry=exclusive] input[name=exclusive]', container);

--- a/test/spec/provider/activiti/CamundaPropertiesProviderSpec.js
+++ b/test/spec/provider/activiti/CamundaPropertiesProviderSpec.js
@@ -80,7 +80,7 @@ describe('camunda-properties', function() {
 
       var shape = elementRegistry.get('ServiceTask_1'),
           groupSelector = '[data-group=jobConfiguration]',
-          inputSelector = 'div[data-entry=asyncBefore] input[name=asyncBefore]';
+          inputSelector = 'div[data-entry=async] input[name=async]';
 
       // given
       selection.select(shape);

--- a/test/spec/provider/activiti/CamundaPropertiesProviderSpec.js
+++ b/test/spec/provider/activiti/CamundaPropertiesProviderSpec.js
@@ -85,10 +85,10 @@ describe('camunda-properties', function() {
       // given
       selection.select(shape);
 
-      var asyncBeforeCheckbox = domQuery(inputSelector, propertiesPanel._container);
+      var activitiAsyncCheckbox = domQuery(inputSelector, propertiesPanel._container);
 
       // when
-      TestHelper.triggerEvent(asyncBeforeCheckbox, 'click');
+      TestHelper.triggerEvent(activitiAsyncCheckbox, 'click');
       var group = domQuery(groupSelector, propertiesPanel._container);
 
       // then

--- a/test/spec/provider/activiti/FormData.bpmn
+++ b/test/spec/provider/activiti/FormData.bpmn
@@ -39,7 +39,7 @@
         <activiti:taskListener expression="abc" event="assignment" />
       </bpmn2:extensionElements>
     </bpmn2:userTask>
-    <bpmn2:userTask id="UserTask_3" activiti:asyncAfter="true">
+    <bpmn2:userTask id="UserTask_3" activiti:async="true">
       <bpmn2:extensionElements>
         <activiti:failedJobRetryTimeCycle>123</activiti:failedJobRetryTimeCycle>
       </bpmn2:extensionElements>

--- a/test/spec/provider/activiti/JobPriority.bpmn
+++ b/test/spec/provider/activiti/JobPriority.bpmn
@@ -7,7 +7,7 @@
 
   <bpmn2:process id="Process_1" isExecutable="false" activiti:jobPriority="9000">
 
-    <bpmn2:serviceTask id="ServiceTask" activiti:asyncBefore="true" activiti:jobPriority="100" />
+    <bpmn2:serviceTask id="ServiceTask" activiti:async="true" activiti:jobPriority="100" />
 
     <bpmn2:intermediateCatchEvent id="IntermediateCatchEvent">
       <bpmn2:timerEventDefinition id="_TimerEventDefinition_2"/>

--- a/test/spec/provider/activiti/MultiInstanceLoop.bpmn
+++ b/test/spec/provider/activiti/MultiInstanceLoop.bpmn
@@ -2,14 +2,14 @@
 <bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:activiti="http://activiti.org/bpmn" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:fox="http://www.camunda.com/fox" id="_GcxxcClBEeW1G85egYVLqw" targetNamespace="http://activiti.org/bpmn" exporter="camunda modeler" exporterVersion="2.7.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
   <bpmn2:process id="Process_1" isExecutable="false">
     <bpmn2:serviceTask id="ServiceTask">
-      <bpmn2:multiInstanceLoopCharacteristics activiti:asyncBefore="true">
+      <bpmn2:multiInstanceLoopCharacteristics activiti:async="true">
         <bpmn2:loopCardinality xsi:type="bpmn2:tFormalExpression">card</bpmn2:loopCardinality>
         <bpmn2:completionCondition xsi:type="bpmn2:tFormalExpression">cond</bpmn2:completionCondition>
       </bpmn2:multiInstanceLoopCharacteristics>
     </bpmn2:serviceTask>
     <bpmn2:serviceTask id="ServiceTask2" />
     <bpmn2:serviceTask id="ServiceTask3">
-      <bpmn2:multiInstanceLoopCharacteristics activiti:asyncBefore="true" activiti:collection="coll" activiti:elementVariable="collVal">
+      <bpmn2:multiInstanceLoopCharacteristics activiti:async="true" activiti:collection="coll" activiti:elementVariable="collVal">
         <bpmn2:extensionElements>
           <fox:failedJobRetryTimeCycle>asd</fox:failedJobRetryTimeCycle>
           <activiti:failedJobRetryTimeCycle>asd</activiti:failedJobRetryTimeCycle>
@@ -23,7 +23,7 @@
       </bpmn2:multiInstanceLoopCharacteristics>
     </bpmn2:serviceTask>
     <bpmn2:serviceTask id="ServiceTask5">
-      <bpmn2:multiInstanceLoopCharacteristics activiti:asyncBefore="true" activiti:collection="coll" activiti:elementVariable="collVal">
+      <bpmn2:multiInstanceLoopCharacteristics activiti:async="true" activiti:collection="coll" activiti:elementVariable="collVal">
         <bpmn2:extensionElements>
           <activiti:failedJobRetryTimeCycle>asd</activiti:failedJobRetryTimeCycle>
         </bpmn2:extensionElements>

--- a/test/spec/provider/activiti/MultiInstanceLoopSpec.js
+++ b/test/spec/provider/activiti/MultiInstanceLoopSpec.js
@@ -52,12 +52,12 @@ function getErrorMessageEntry(container) {
 }
 
 function getAsyncBefore(container) {
-  return getInputField(container, 'multiInstance-asyncBefore', 'asyncBefore');
+  return getInputField(container, 'multiInstance-async', 'async');
 }
 
-function getAsyncAfter(container) {
-  return getInputField(container, 'multiInstance-asyncAfter', 'asyncAfter');
-}
+// function getAsyncAfter(container) {
+//   return getInputField(container, 'multiInstance-asyncAfter', 'asyncAfter');
+// }
 
 function getExclusive(container) {
   return getInputField(container, 'multiInstance-exclusive', 'exclusive');
@@ -1168,7 +1168,7 @@ describe('multiInstance-loop-properties', function() {
     var input = getAsyncBefore(propertiesPanel._container),
         businessObject = getBusinessObject(shape).get('loopCharacteristics');
 
-    expect(input.checked).to.equal(!!businessObject.get('asyncBefore'));
+    expect(input.checked).to.equal(!!businessObject.get('async'));
     expect(input.checked).to.be.ok;
   }));
 
@@ -1190,42 +1190,42 @@ describe('multiInstance-loop-properties', function() {
     var businessObject = getBusinessObject(shape).get('loopCharacteristics');
 
     // then
-    expect(businessObject.get('asyncBefore')).to.not.be.ok;
+    expect(businessObject.get('async')).to.not.be.ok;
     expect(input.checked).to.not.be.ok;
   }));
 
 
-  it('should fetch the multi instance async after property for an element', inject(function(propertiesPanel, selection, elementRegistry) {
+  // it('should fetch the multi instance async after property for an element', inject(function(propertiesPanel, selection, elementRegistry) {
 
-    var shape = elementRegistry.get('ServiceTask');
-    selection.select(shape);
+  //   var shape = elementRegistry.get('ServiceTask');
+  //   selection.select(shape);
 
-    var input = getAsyncAfter(propertiesPanel._container),
-        businessObject = getBusinessObject(shape).get('loopCharacteristics');
+  //   var input = getAsyncAfter(propertiesPanel._container),
+  //       businessObject = getBusinessObject(shape).get('loopCharacteristics');
 
-    expect(input.checked).to.equal(!!businessObject.get('asyncAfter'));
-    expect(input.checked).to.not.be.ok;
-  }));
+  //   expect(input.checked).to.equal(!!businessObject.get('asyncAfter'));
+  //   expect(input.checked).to.not.be.ok;
+  // }));
 
 
-  it('should set the multi instance async after property for an element', inject(function(propertiesPanel, selection, elementRegistry) {
+  // it('should set the multi instance async after property for an element', inject(function(propertiesPanel, selection, elementRegistry) {
 
-    var shape = elementRegistry.get('ServiceTask');
-    selection.select(shape);
+  //   var shape = elementRegistry.get('ServiceTask');
+  //   selection.select(shape);
 
-    var businessObject = getBusinessObject(shape).get('loopCharacteristics');
-    var input = getAsyncAfter(propertiesPanel._container);
+  //   var businessObject = getBusinessObject(shape).get('loopCharacteristics');
+  //   var input = getAsyncAfter(propertiesPanel._container);
 
-    // given
-    expect(input.checked).to.not.be.ok;
+  //   // given
+  //   expect(input.checked).to.not.be.ok;
 
-    // when
-    TestHelper.triggerEvent(input, 'click');
+  //   // when
+  //   TestHelper.triggerEvent(input, 'click');
 
-    // then
-    expect(businessObject.get('asyncBefore')).to.be.ok;
-    expect(input.checked).to.be.ok;
-  }));
+  //   // then
+  //   expect(businessObject.get('async')).to.be.ok;
+  //   expect(input.checked).to.be.ok;
+  // }));
 
 
   it('should fetch the multi instance exclusive property for an element', inject(function(propertiesPanel, selection, elementRegistry) {

--- a/test/spec/provider/activiti/MultiInstanceLoopSpec.js
+++ b/test/spec/provider/activiti/MultiInstanceLoopSpec.js
@@ -55,10 +55,6 @@ function getAsyncBefore(container) {
   return getInputField(container, 'multiInstance-async', 'async');
 }
 
-// function getAsyncAfter(container) {
-//   return getInputField(container, 'multiInstance-asyncAfter', 'asyncAfter');
-// }
-
 function getExclusive(container) {
   return getInputField(container, 'multiInstance-exclusive', 'exclusive');
 }
@@ -1193,39 +1189,6 @@ describe('multiInstance-loop-properties', function() {
     expect(businessObject.get('async')).to.not.be.ok;
     expect(input.checked).to.not.be.ok;
   }));
-
-
-  // it('should fetch the multi instance async after property for an element', inject(function(propertiesPanel, selection, elementRegistry) {
-
-  //   var shape = elementRegistry.get('ServiceTask');
-  //   selection.select(shape);
-
-  //   var input = getAsyncAfter(propertiesPanel._container),
-  //       businessObject = getBusinessObject(shape).get('loopCharacteristics');
-
-  //   expect(input.checked).to.equal(!!businessObject.get('asyncAfter'));
-  //   expect(input.checked).to.not.be.ok;
-  // }));
-
-
-  // it('should set the multi instance async after property for an element', inject(function(propertiesPanel, selection, elementRegistry) {
-
-  //   var shape = elementRegistry.get('ServiceTask');
-  //   selection.select(shape);
-
-  //   var businessObject = getBusinessObject(shape).get('loopCharacteristics');
-  //   var input = getAsyncAfter(propertiesPanel._container);
-
-  //   // given
-  //   expect(input.checked).to.not.be.ok;
-
-  //   // when
-  //   TestHelper.triggerEvent(input, 'click');
-
-  //   // then
-  //   expect(businessObject.get('async')).to.be.ok;
-  //   expect(input.checked).to.be.ok;
-  // }));
 
 
   it('should fetch the multi instance exclusive property for an element', inject(function(propertiesPanel, selection, elementRegistry) {

--- a/test/spec/provider/activiti/MultiInstanceLoopSpec.js
+++ b/test/spec/provider/activiti/MultiInstanceLoopSpec.js
@@ -1266,16 +1266,16 @@ describe('multiInstance-loop-properties', function() {
     selection.select(shape);
 
     var exclusiveInput = getExclusive(propertiesPanel._container),
-        asyncBeforeInput = getAsyncBefore(propertiesPanel._container);
+        activitiAsyncInput = getAsyncBefore(propertiesPanel._container);
     var businessObject = getBusinessObject(shape).get('loopCharacteristics');
 
     // given
     expect(exclusiveInput.checked).to.be.ok;
-    expect(asyncBeforeInput.checked).to.be.ok;
+    expect(activitiAsyncInput.checked).to.be.ok;
 
     // when
     TestHelper.triggerEvent(exclusiveInput, 'click'); // change the value of the exclusive field
-    TestHelper.triggerEvent(asyncBeforeInput, 'click'); // reset the exclusive field
+    TestHelper.triggerEvent(activitiAsyncInput, 'click'); // reset the exclusive field
 
     // then
     expect(exclusiveInput.checked).to.equal(businessObject.get('exclusive'));
@@ -1303,11 +1303,11 @@ describe('multiInstance-loop-properties', function() {
 
     // given
     selection.select(shape);
-    var asyncBeforeInput = getAsyncBefore(propertiesPanel._container),
+    var activitiAsyncInput = getAsyncBefore(propertiesPanel._container),
         exclusiveEntry = getExclusive(propertiesPanel._container);
 
     // when
-    TestHelper.triggerEvent(asyncBeforeInput, 'click');
+    TestHelper.triggerEvent(activitiAsyncInput, 'click');
 
     // then
     expect(domClasses(exclusiveEntry).has(HIDE_CLASS)).to.be.false;
@@ -1418,11 +1418,11 @@ describe('multiInstance-loop-properties', function() {
 
     // given
     selection.select(shape);
-    var asyncBeforeInput = getAsyncBefore(propertiesPanel._container),
+    var activitiAsyncInput = getAsyncBefore(propertiesPanel._container),
         jobRetryEntry = getCycle(propertiesPanel._container);
 
     // when
-    TestHelper.triggerEvent(asyncBeforeInput, 'click');
+    TestHelper.triggerEvent(activitiAsyncInput, 'click');
 
     // then
     expect(domClasses(jobRetryEntry.parentElement).has(HIDE_CLASS)).to.be.false;

--- a/test/spec/provider/activiti/RetryTimeCycle.bpmn
+++ b/test/spec/provider/activiti/RetryTimeCycle.bpmn
@@ -12,12 +12,12 @@
     <bpmn2:intermediateCatchEvent id="IntermediateThrowEvent">
       <bpmn2:timerEventDefinition id="_TimerEventDefinition_2" />
     </bpmn2:intermediateCatchEvent>
-    <bpmn2:serviceTask id="WITH_LISTENER" activiti:asyncBefore="true">
+    <bpmn2:serviceTask id="WITH_LISTENER" activiti:async="true">
       <bpmn2:extensionElements>
         <activiti:executionListener class="foo" event="start" />
       </bpmn2:extensionElements>
     </bpmn2:serviceTask>
-    <bpmn2:serviceTask id="WITH_LISTENER_AND_CYCLE" activiti:asyncBefore="true">
+    <bpmn2:serviceTask id="WITH_LISTENER_AND_CYCLE" activiti:async="true">
       <bpmn2:extensionElements>
         <activiti:executionListener class="foo" event="start" />
         <activiti:failedJobRetryTimeCycle>foo</activiti:failedJobRetryTimeCycle>

--- a/test/spec/provider/activiti/RetryTimeCycleSpec.js
+++ b/test/spec/provider/activiti/RetryTimeCycleSpec.js
@@ -80,7 +80,7 @@ describe('retryTimeCycle', function() {
 
     selection.select(shape);
 
-    var asyncField = domQuery('input[name=asyncBefore]', propertiesPanel._container),
+    var asyncField = domQuery('input[name=async]', propertiesPanel._container),
         retryField = domQuery(inputEl, propertiesPanel._container);
 
     // given

--- a/test/spec/provider/activiti/element-templates/cmd/ChangeElementTemplateHandlerSpec.js
+++ b/test/spec/provider/activiti/element-templates/cmd/ChangeElementTemplateHandlerSpec.js
@@ -122,11 +122,11 @@ describe('element-templates - cmd', function() {
         // when
         applyTemplate(taskShape, newTemplate);
 
-        var asyncBefore = task.get('activiti:asyncBefore'),
+        var activitiAsync = task.get('activiti:async'),
             elementTemplate = task.modelerTemplate;
 
         // then
-        expect(asyncBefore).to.be.true;
+        expect(activitiAsync).to.be.true;
         expect(elementTemplate).to.exist;
         expect(elementTemplate).to.equal('my.awesome.Task');
       }));
@@ -144,11 +144,11 @@ describe('element-templates - cmd', function() {
         // when
         commandStack.undo();
 
-        var asyncBefore = task.get('activiti:asyncBefore'),
+        var activitiAsync = task.get('activiti:async'),
             elementTemplate = task.modelerTemplate;
 
         // then
-        expect(asyncBefore).to.be.false;
+        expect(activitiAsync).to.be.false;
         expect(elementTemplate).not.to.exist;
       }));
 
@@ -662,7 +662,7 @@ describe('element-templates - cmd', function() {
 
         // removing a task template does
         // not change the applied values
-        expect(task.get('activiti:asyncBefore')).to.be.true;
+        expect(task.get('activiti:async')).to.be.true;
       }));
 
 
@@ -680,7 +680,7 @@ describe('element-templates - cmd', function() {
         // then
         expect(task.get('activiti:modelerTemplate')).to.eql(currentTemplate.id);
 
-        expect(task.get('activiti:asyncBefore')).to.be.true;
+        expect(task.get('activiti:async')).to.be.true;
       }));
 
     });

--- a/test/spec/provider/activiti/element-templates/cmd/better-async-task.json
+++ b/test/spec/provider/activiti/element-templates/cmd/better-async-task.json
@@ -10,7 +10,7 @@
       "value": true,
       "binding": {
         "type": "property",
-        "name": "activiti:asyncBefore"
+        "name": "activiti:async"
       }
     }
   ]

--- a/test/spec/provider/activiti/element-templates/parts/CustomProps.bpmn
+++ b/test/spec/provider/activiti/element-templates/parts/CustomProps.bpmn
@@ -30,7 +30,7 @@
         </activiti:inputOutput>
       </bpmn:extensionElements>
     </bpmn:task>
-    <bpmn:task id="AsyncTask" name="AsyncTask" activiti:asyncBefore="true" activiti:modelerTemplate="my.awesome.Task" />
+    <bpmn:task id="AsyncTask" name="AsyncTask" activiti:async="true" activiti:modelerTemplate="my.awesome.Task" />
     <bpmn:task id="WebserviceTask" name="Webservice Task" activiti:modelerTemplate="com.mycompany.WsCaller">
       <bpmn:extensionElements>
         <activiti:properties>

--- a/test/spec/provider/activiti/element-templates/parts/CustomProps.json
+++ b/test/spec/provider/activiti/element-templates/parts/CustomProps.json
@@ -168,7 +168,7 @@
         "value": true,
         "binding": {
           "type": "property",
-          "name": "activiti:asyncBefore"
+          "name": "activiti:async"
         }
       }
     ],
@@ -176,8 +176,7 @@
       "_all": false,
       "id": true,
       "name": true,
-      "asyncBefore": true,
-      "asyncAfter": true,
+      "async": true,
       "executionListeners": true,
       "documentation": true
     }

--- a/test/spec/provider/activiti/element-templates/parts/CustomPropsSpec.js
+++ b/test/spec/provider/activiti/element-templates/parts/CustomPropsSpec.js
@@ -55,7 +55,7 @@ describe('element-templates/parts - Custom Properties', function() {
         TestHelper.triggerEvent(checkbox, 'click');
 
         // then
-        expect(task.get('activiti:asyncBefore')).to.be.false;
+        expect(task.get('activiti:async')).to.be.false;
       }));
 
 

--- a/test/spec/provider/activiti/element-templates/parts/EntryActivation-editable.json
+++ b/test/spec/provider/activiti/element-templates/parts/EntryActivation-editable.json
@@ -11,7 +11,7 @@
         "type": "Boolean",
         "binding": {
           "type": "property",
-          "name": "activiti:asyncBefore"
+          "name": "activiti:async"
         }
       },
       {
@@ -20,7 +20,7 @@
         "editable": false,
         "binding": {
           "type": "property",
-          "name": "activiti:asyncBefore"
+          "name": "activiti:async"
         }
       },
       {

--- a/test/spec/provider/activiti/element-templates/parts/Visibility.json
+++ b/test/spec/provider/activiti/element-templates/parts/Visibility.json
@@ -28,8 +28,7 @@
     "entriesVisible": {
       "_all": true,
       "name": false,
-      "asyncBefore": false,
-      "asyncAfter": false,
+      "async": false,
       "executionListeners": false,
       "documentation": false
     }
@@ -42,8 +41,7 @@
     ],
     "properties": [],
     "entriesVisible": {
-      "asyncBefore": true,
-      "asyncAfter": true,
+      "async": true,
       "executionListeners": true,
       "documentation": true
     }

--- a/test/spec/provider/activiti/element-templates/parts/VisibilitySpec.js
+++ b/test/spec/provider/activiti/element-templates/parts/VisibilitySpec.js
@@ -74,7 +74,6 @@ describe('element-templates/parts - Visibility', function() {
       expectHidden([
         'name',
         'async',
-        //'asyncAfter',
         'documentation',
         'executionListeners'
       ]);
@@ -90,7 +89,6 @@ describe('element-templates/parts - Visibility', function() {
       expectShown([
         'elementTemplate-chooser',
         'async',
-        //'asyncAfter',
         'executionListeners',
         'documentation'
       ]);

--- a/test/spec/provider/activiti/element-templates/parts/VisibilitySpec.js
+++ b/test/spec/provider/activiti/element-templates/parts/VisibilitySpec.js
@@ -32,7 +32,7 @@ describe('element-templates/parts - Visibility', function() {
     ]);
 
     expectHidden([
-      'asyncBefore',
+      'async',
       'executionListeners'
     ]);
   }));
@@ -51,7 +51,7 @@ describe('element-templates/parts - Visibility', function() {
         'name',
         'elementTemplate-chooser',
         'documentation',
-        'asyncBefore',
+        'async',
         'executionListeners',
         'properties'
       ]);
@@ -73,8 +73,8 @@ describe('element-templates/parts - Visibility', function() {
 
       expectHidden([
         'name',
-        'asyncBefore',
-        'asyncAfter',
+        'async',
+        //'asyncAfter',
         'documentation',
         'executionListeners'
       ]);
@@ -89,8 +89,8 @@ describe('element-templates/parts - Visibility', function() {
       // then
       expectShown([
         'elementTemplate-chooser',
-        'asyncBefore',
-        'asyncAfter',
+        'async',
+        //'asyncAfter',
         'executionListeners',
         'documentation'
       ]);

--- a/test/spec/provider/bpmn/PropertyEntryFieldsSpec.js
+++ b/test/spec/provider/bpmn/PropertyEntryFieldsSpec.js
@@ -95,7 +95,7 @@ describe('properties-entry-fields', function() {
   it('should create a checkbox field', inject(function(propertiesPanel, selection, elementRegistry) {
 
     // given
-    var inputEl = 'input[name=asyncBefore]';
+    var inputEl = 'input[name=async]';
     var userTaskShape = elementRegistry.get('UserTask');
 
     // when


### PR DESCRIPTION
<!--

Thanks for filing a pull request!

Make sure you've read through [our contributing guide](https://github.com/bpmn-io/bpmn-js/blob/master/CONTRIBUTING.md#creating-a-pull-request) before you continue.

-->

### Proposed Changes

* Removed editing Camunda's `asyncBefore` and `asyncAfter` attributes for asynchronous continuations
* Enabled editing Activiti's  `async attributes for asynchronous continuations

![image](https://user-images.githubusercontent.com/20428629/64925546-e6e7ba80-d7a6-11e9-8042-4ef023bbcb78.png)
